### PR TITLE
Fix the type string we check for to determine if a media has hls assets

### DIFF
--- a/Pod/Classes/public/model/WistiaMedia.swift
+++ b/Pod/Classes/public/model/WistiaMedia.swift
@@ -95,7 +95,7 @@ public struct WistiaMedia {
      - Note: hlsMasterIndexManifestURL is valid for playback iff this returns true.
      **/
     public func hasHlsAssets() -> Bool {
-        return assets.contains { $0.type == "HlsVideoFile" }
+        return assets.contains { $0.type == "hls_video" }
     }
 
     // MARK: - ------------Internal------------

--- a/Pod/Classes/public/model/WistiaMedia.swift
+++ b/Pod/Classes/public/model/WistiaMedia.swift
@@ -95,7 +95,7 @@ public struct WistiaMedia {
      - Note: hlsMasterIndexManifestURL is valid for playback iff this returns true.
      **/
     public func hasHlsAssets() -> Bool {
-        return assets.contains { $0.type == "hls_video" }
+        return assets.contains { $0.type.lowercased().contains("hls") }
     }
 
     // MARK: - ------------Internal------------


### PR DESCRIPTION
A customer reported that some of their videos were playing back in a "laggy" way. Upon further inspection, @jayholman and I noticed that WistiaKit was choosing the 1 FPS mp4 asset for playback, even though the video had HLS assets, and normal MP4 assets. Here's a copy of the video in question: `eyk5ougyfd`. You can reproduce the issue by playing the media in the `pod try wistiakit` demo.

Upon even further inspection, by printing the value of `media.hasHlsAssets()` to the console at https://github.com/wistia/WistiaKit/blob/6d1729645bfcdbb1d8720888f6292050a9a89561/Pod/Classes/internal/_WistiaPlayer.swift#L97, we found that it was returning `false` when it should clearly return `true`.  🤔 

We also noticed that this was affecting other videos that definitely had HLS assets, besides just this customer's. While they didn't play the 1 FPS mp4, as in the customer's case, they were playing regular mp4 files instead of using HLS adaptive streaming. We determined this by calling `print(url)` just after https://github.com/wistia/WistiaKit/blob/6d1729645bfcdbb1d8720888f6292050a9a89561/Pod/Classes/internal/_WistiaPlayer.swift#L51.

As it turns out, the `type` for HLS assets in the `assets` object (if that's the right lingo... or is it a dictionary?) is `hls_video`, not `hlsVideoFile`. This is quite strange, because the `type` for an HLS asset in the API response for the `medias#show` endpoint, `https://api.wistia.com/v1/medias/<media-hashed-id>.json`, _is_ `hlsVideoFile`. 

We don't understand where `hlsVideoFile` is getting lost, and how `hls_video` is getting in there as the `type`. This change to the `hasHlsAssets` function fixes the problem, but perhaps a better fix would be to address that root cause instead. 

@spinosa, what say you?

P.S. This PR doesn't address the fact that the low FPS mp4 asset ever gets selected for playback. That should never happen, so I'll open an issue for that.