### PR TITLE
Quelling Swift 3.1 warnings

### DIFF
--- a/Pod/Classes/internal/stats/_WistiaStatsManager.swift
+++ b/Pod/Classes/internal/stats/_WistiaStatsManager.swift
@@ -143,7 +143,7 @@ internal class WistiaStatsManager {
             Alamofire.request(event.url, method: .post, parameters: event.json, encoding: JsonToBase64InBodyEncoder(json: event.json), headers: nil)
                 .response(completionHandler: { (dataResponse) in
                     if dataResponse.error != nil {
-                        print("ERROR sending stats: \(dataResponse.error)")
+                        print("ERROR sending stats: \(String(describing: dataResponse.error))")
                         if event.ttl > 0 {
                             self.eventsPending.append(StatsEvent(url: event.url, json: event.json, ttl: event.ttl-1))
                         } else {

--- a/Pod/Classes/internal/view controller/_WistiaPlayerViewController.swift
+++ b/Pod/Classes/internal/view controller/_WistiaPlayerViewController.swift
@@ -39,13 +39,13 @@ extension WistiaPlayerViewController {
 
             switch UIApplication.shared.statusBarOrientation {
             case .landscapeLeft:
-                transform = CGAffineTransform(rotationAngle: CGFloat(M_PI_2))
+                transform = CGAffineTransform(rotationAngle: CGFloat.pi/2)
                 invertSize = true
             case .landscapeRight:
-                transform = CGAffineTransform(rotationAngle: CGFloat(-M_PI_2))
+                transform = CGAffineTransform(rotationAngle: -CGFloat.pi/2)
                 invertSize = true
             case .portraitUpsideDown:
-                transform = CGAffineTransform(rotationAngle: CGFloat(M_PI))
+                transform = CGAffineTransform(rotationAngle: CGFloat.pi/2)
                 invertSize = false
             default: //.Portrait
                 transform = CGAffineTransform.identity
@@ -81,7 +81,7 @@ extension WistiaPlayerViewController {
                     //To counter-rotate against 180, we first (1) under-counter-rotate by some small amount in the
                     //animation block then (2) finish the rotation after the animation block.  As long as we under-rotate
                     //by a small enough amount, it's imperceptible, and our views stay perfectly square afterward.
-                    counterTransform = CGAffineTransform(rotationAngle: -1*(CGFloat(M_PI)-0.00001))
+                    counterTransform = CGAffineTransform(rotationAngle: -1*(CGFloat.pi-0.00001))
                     completionTransform = CGAffineTransform(rotationAngle: -0.00001)
                 } else {
                     //just invert the 90 degree transforms

--- a/Pod/Classes/internal/view/_Wistia360PlayerView+LookVectorTracking.swift
+++ b/Pod/Classes/internal/view/_Wistia360PlayerView+LookVectorTracking.swift
@@ -84,8 +84,8 @@ internal extension Wistia360PlayerView {
 
     //Convert from latitude and longitude to the heading and pitch wanted for back end analytics
     fileprivate func correctedHeadingPitchFrom(_ latlon: LatitudeLongitude) -> HeadingPitch {
-        let heading = latlon.longitude * 90.0 / Float(M_PI_2)
-        let pitch = (latlon.latitude * 180.0 / Float(M_PI_2)) - 180.0
+        let heading = latlon.longitude * 90.0 / Float.pi/2
+        let pitch = latlon.latitude * 180.0 / Float.pi/2 - 180.0
         return (heading, pitch)
     }
     

--- a/Pod/Classes/internal/view/_Wistia360PlayerView.swift
+++ b/Pod/Classes/internal/view/_Wistia360PlayerView.swift
@@ -86,8 +86,8 @@ internal class Wistia360PlayerView: UIView {
 
     fileprivate var animatingPitch = false
     fileprivate var manualEuler = SCNVector3Make(0, 0, 0)
-    fileprivate let ManualPitchCapUp = Float(85.0*M_PI/180.0)
-    fileprivate let ManualPitchCapDown = Float(60.0*M_PI/180.0)
+    fileprivate let ManualPitchCapUp = 85.0*Float.pi/180.0
+    fileprivate let ManualPitchCapDown = 60.0*Float.pi/180.0
 
     //Look Vector (aka Camera Position) Tracking
     //mostly in the extension, but can't (easily) add stored variables in extensions
@@ -316,7 +316,7 @@ internal class Wistia360PlayerView: UIView {
         cameraHolderNode.position = cameraNode.position
         cameraHolderNode.addChildNode(cameraNode)
         // When running without device motion, camera should be setup to look ahead
-        cameraHolderNode.transform = SCNMatrix4MakeRotation(-Float(M_PI_2), -1, 0, 0)
+        cameraHolderNode.transform = SCNMatrix4MakeRotation(-Float.pi/2, -1, 0, 0)
         scene.rootNode.addChildNode(cameraHolderNode)
 
         // 3b) Sphere
@@ -333,7 +333,7 @@ internal class Wistia360PlayerView: UIView {
         sphereNode = SCNNode(geometry: sphere)
         // Reorient sphere to account for default texture mapping (upside down, backwards)
         // and device motion (natural state is device laying on back)
-        sphereNode.transform = SCNMatrix4MakeRotation(-Float(M_PI_2), 1, 0, 0)
+        sphereNode.transform = SCNMatrix4MakeRotation(-Float.pi/2, 1, 0, 0)
 
         scene.rootNode.addChildNode(sphereNode)
     }
@@ -378,8 +378,8 @@ internal class Wistia360PlayerView: UIView {
                 let endLat = asin(endHit.localCoordinates.y / Float(SphereRadius))
                 var deltaLong = endLong - startLong
                 //Keep delta small in correct direction when crossing from -pi to +pi (and vice versa)
-                if fabs(deltaLong) > Float(M_PI) {
-                    deltaLong = (Float(M_PI) - fabs(endLong)) + (Float(M_PI) - fabs(startLong))
+                if fabs(deltaLong) > Float.pi {
+                    deltaLong = (Float.pi - fabs(endLong)) + (Float.pi - fabs(startLong))
                     if translation.x < 0 {
                         deltaLong = -deltaLong
                     }


### PR DESCRIPTION
I removed deprecated macros like `M_PI` in lieu of `Float.pi`, `CGFloat.pi`, and `Double.pi`, as necessary. This also has a nice side effect of minimizing the casting that was taking place to do a calculation with Swift's type system.