### PR TITLE
Support playback when entering the background

### DIFF
--- a/Pod/Classes/Playback/public/WistiaFlatPlayerView.swift
+++ b/Pod/Classes/Playback/public/WistiaFlatPlayerView.swift
@@ -15,6 +15,7 @@ import AVKit
 import AVFoundation
 
 public class WistiaFlatPlayerView: UIView {
+    private var detachedAVPlayer: AVPlayer?
 
     override public class var layerClass: AnyClass {
         get {
@@ -25,6 +26,20 @@ public class WistiaFlatPlayerView: UIView {
     public var wistiaPlayer:WistiaPlayer? {
         didSet {
             (self.layer as! AVPlayerLayer).player = wistiaPlayer?.avPlayer
+        }
+    }
+    
+    public func prepareForBackgroundPlayback() {
+        if let playerLayer = layer as? AVPlayerLayer {
+            detachedAVPlayer = playerLayer.player
+            playerLayer.player = nil
+        }
+    }
+    
+    public func returnToForegroundPlayback() {
+        if let playerLayer = layer as? AVPlayerLayer {
+            playerLayer.player = detachedAVPlayer
+            detachedAVPlayer = nil
         }
     }
 

--- a/Pod/Classes/Playback/public/WistiaFlatPlayerView.swift
+++ b/Pod/Classes/Playback/public/WistiaFlatPlayerView.swift
@@ -30,17 +30,14 @@ public class WistiaFlatPlayerView: UIView {
     }
     
     public func prepareForBackgroundPlayback() {
-        if let playerLayer = layer as? AVPlayerLayer {
-            detachedAVPlayer = playerLayer.player
-            playerLayer.player = nil
-        }
+        let playerLayer = layer as! AVPlayerLayer
+        detachedAVPlayer = playerLayer.player
+        playerLayer.player = nil
     }
     
     public func returnToForegroundPlayback() {
-        if let playerLayer = layer as? AVPlayerLayer {
-            playerLayer.player = detachedAVPlayer
-            detachedAVPlayer = nil
-        }
+        (layer as! AVPlayerLayer).player = detachedAVPlayer
+        detachedAVPlayer = nil
     }
 
 }

--- a/Pod/Classes/Playback/public/WistiaFlatPlayerView.swift
+++ b/Pod/Classes/Playback/public/WistiaFlatPlayerView.swift
@@ -7,7 +7,7 @@
 //
 //  A View backed by an AVPlayerLayer.
 //
-//  Set the wistiaPlayer and this view will pass it's AVPlayer through to the backing AVPlayerLayer.
+//  Set the wistiaPlayer and this view will pass its AVPlayer through to the backing AVPlayerLayer.
 //
 
 import UIKit

--- a/Pod/Classes/Playback/public/WistiaPlayer.swift
+++ b/Pod/Classes/Playback/public/WistiaPlayer.swift
@@ -644,7 +644,7 @@ public final class WistiaPlayer: NSObject {
     // XXX: This should be revisited when we have HLS assets for 360 videos
     internal let SphericalTargetAssetWidth:Int64 = 1920
 
-    //Raw Observeration
+    //Raw Observation
     internal var playerItemContext = 1
     internal var playerContext = 2
     internal var periodicTimeObserver: Any?

--- a/Pod/Classes/Playback/public/WistiaPlayerViewController.swift
+++ b/Pod/Classes/Playback/public/WistiaPlayerViewController.swift
@@ -83,6 +83,20 @@ public protocol WistiaPlayerViewControllerDelegate : class {
      */
     func wistiaPlayerViewController(_ vc: WistiaPlayerViewController, activityViewControllerDidCompleteForMedia media:WistiaMedia, withActivityType activityType: String?, completed: Bool, activityError: Error?)
 
+    /**
+     Determines whether playback continues (with audio only) when your app enters the background.
+     
+     When your app is in the background, audio playback can be manipulated via the Control Center or using headphone controls.
+     
+     - Parameter vc: The `WistiaPlayerViewController` whose hosting app is entering the background.
+    */
+    func shouldContinuePlaybackWhenEnteringBackground(_ vc: WistiaPlayerViewController) -> Bool
+}
+
+public extension WistiaPlayerViewControllerDelegate {
+    public func shouldContinuePlaybackWhenEnteringBackground(_: WistiaPlayerViewController) -> Bool {
+        return false
+    }
 }
 
 

--- a/Pod/Classes/Playback/public/WistiaPlayerViewController.swift
+++ b/Pod/Classes/Playback/public/WistiaPlayerViewController.swift
@@ -435,7 +435,9 @@ public final class WistiaPlayerViewController: UIViewController {
 
         NotificationCenter.default.addObserver(forName: NSNotification.Name.UIApplicationDidBecomeActive, object: nil, queue: nil) { [weak self] _ in
             if let strongSelf = self {
-                strongSelf.playerFlatView.returnToForegroundPlayback()
+                if let delegate = strongSelf.delegate, delegate.shouldContinuePlaybackWhenEnteringBackground(strongSelf) {
+                    strongSelf.playerFlatView.returnToForegroundPlayback()
+                }
 
                 //It seems that SpriteKit always resumes a SKVideoNode when app resumes, so we need to cancel
                 if strongSelf.playing360 && !strongSelf.autoplayVideoWhenReady {
@@ -447,7 +449,10 @@ public final class WistiaPlayerViewController: UIViewController {
         NotificationCenter.default.addObserver(forName: NSNotification.Name.UIApplicationDidEnterBackground, object: nil, queue: nil) { [weak self] note in
             if let strongSelf = self {
                 strongSelf.autoplayVideoWhenReady = false
-                strongSelf.playerFlatView.prepareForBackgroundPlayback()
+                
+                if let delegate = strongSelf.delegate, delegate.shouldContinuePlaybackWhenEnteringBackground(strongSelf) {
+                    strongSelf.playerFlatView.prepareForBackgroundPlayback()
+                }
             }
         }
         

--- a/Pod/Classes/Playback/public/WistiaPlayerViewController.swift
+++ b/Pod/Classes/Playback/public/WistiaPlayerViewController.swift
@@ -434,25 +434,25 @@ public final class WistiaPlayerViewController: UIViewController {
 
 
         NotificationCenter.default.addObserver(forName: NSNotification.Name.UIApplicationDidBecomeActive, object: nil, queue: nil) { [weak self] _ in
-            if let strongSelf = self {
-                if let delegate = strongSelf.delegate, delegate.shouldContinuePlaybackWhenEnteringBackground(strongSelf) {
-                    strongSelf.playerFlatView.returnToForegroundPlayback()
-                }
-
-                //It seems that SpriteKit always resumes a SKVideoNode when app resumes, so we need to cancel
-                if strongSelf.playing360 && !strongSelf.autoplayVideoWhenReady {
-                    strongSelf.pause()
-                }
+            guard let strongSelf = self else { return }
+            
+            if let delegate = strongSelf.delegate, delegate.shouldContinuePlaybackWhenEnteringBackground(strongSelf) {
+                strongSelf.playerFlatView.returnToForegroundPlayback()
+            }
+            
+            //It seems that SpriteKit always resumes a SKVideoNode when app resumes, so we need to cancel
+            if strongSelf.playing360 && !strongSelf.autoplayVideoWhenReady {
+                strongSelf.pause()
             }
         }
         
         NotificationCenter.default.addObserver(forName: NSNotification.Name.UIApplicationDidEnterBackground, object: nil, queue: nil) { [weak self] note in
-            if let strongSelf = self {
-                strongSelf.autoplayVideoWhenReady = false
-                
-                if let delegate = strongSelf.delegate, delegate.shouldContinuePlaybackWhenEnteringBackground(strongSelf) {
-                    strongSelf.playerFlatView.prepareForBackgroundPlayback()
-                }
+            guard let strongSelf = self else { return }
+            
+            strongSelf.autoplayVideoWhenReady = false
+            
+            if let delegate = strongSelf.delegate, delegate.shouldContinuePlaybackWhenEnteringBackground(strongSelf) {
+                strongSelf.playerFlatView.prepareForBackgroundPlayback()
             }
         }
         

--- a/Pod/Classes/Playback/public/WistiaPlayerViewController.swift
+++ b/Pod/Classes/Playback/public/WistiaPlayerViewController.swift
@@ -408,14 +408,21 @@ public final class WistiaPlayerViewController: UIViewController {
 
 
         //It seems that SpriteKit always resumes a SKVideoNode when app resumes, so we need to cancel
-        NotificationCenter.default.addObserver(forName: NSNotification.Name.UIApplicationDidBecomeActive, object: nil, queue: nil) { [weak self] (_) -> Void in
-            if self != nil && !self!.autoplayVideoWhenReady {
-                self?.pause()
+        NotificationCenter.default.addObserver(forName: NSNotification.Name.UIApplicationDidBecomeActive, object: nil, queue: nil) { [weak self] _ in
+            if let strongSelf = self {
+                strongSelf.playerFlatView.returnToForegroundPlayback()
+    
+                if !strongSelf.autoplayVideoWhenReady {
+                    strongSelf.pause()
+                }
             }
         }
         
-        NotificationCenter.default.addObserver(forName: NSNotification.Name.UIApplicationDidEnterBackground, object: nil, queue: nil) { [weak self] (note) -> Void in
-            self?.autoplayVideoWhenReady = false
+        NotificationCenter.default.addObserver(forName: NSNotification.Name.UIApplicationDidEnterBackground, object: nil, queue: nil) { [weak self] note in
+            if let strongSelf = self {
+                strongSelf.autoplayVideoWhenReady = false
+                strongSelf.playerFlatView.prepareForBackgroundPlayback()
+            }
         }
         
         overlayTapGestureRecognizer.require(toFail: overlayDoubleTapGestureRecognizer)

--- a/Pod/Classes/Playback/public/WistiaPlayerViewController.swift
+++ b/Pod/Classes/Playback/public/WistiaPlayerViewController.swift
@@ -414,12 +414,12 @@ public final class WistiaPlayerViewController: UIViewController {
         wPlayer.captionsRenderer.captionsView = self.captionsLabel
 
 
-        //It seems that SpriteKit always resumes a SKVideoNode when app resumes, so we need to cancel
         NotificationCenter.default.addObserver(forName: NSNotification.Name.UIApplicationDidBecomeActive, object: nil, queue: nil) { [weak self] _ in
             if let strongSelf = self {
                 strongSelf.playerFlatView.returnToForegroundPlayback()
-    
-                if !strongSelf.autoplayVideoWhenReady {
+
+                //It seems that SpriteKit always resumes a SKVideoNode when app resumes, so we need to cancel
+                if strongSelf.playing360 && !strongSelf.autoplayVideoWhenReady {
                     strongSelf.pause()
                 }
             }

--- a/Pod/Classes/Playback/public/WistiaPlayerViewController.swift
+++ b/Pod/Classes/Playback/public/WistiaPlayerViewController.swift
@@ -46,6 +46,13 @@ public protocol WistiaPlayerViewControllerDelegate : class {
      - Parameter vc: The `WistiaPlayerViewController` whose view is about to appear.
     */
     func willAppear(wistiaPlayerViewController vc: WistiaPlayerViewController)
+    
+    /**
+     Called during at the same time as the `UIKit` standard `ViewController.viewWillDisappear()`.
+     
+     - Parameter vc: The `WistiaPlayerViewController` whose view is about to disappear.
+     */
+    func willDisappear(wistiaPlayerViewController vc: WistiaPlayerViewController)
 
     /**
      The user has tapped the action button and the activity view will appear.  Called just before

--- a/Pod/Classes/Playback/public/WistiaPlayerViewController.swift
+++ b/Pod/Classes/Playback/public/WistiaPlayerViewController.swift
@@ -41,14 +41,14 @@ public protocol WistiaPlayerViewControllerDelegate : class {
     func didExitFullscreen(wistiaPlayerViewController vc: WistiaPlayerViewController)
 
     /**
-     Called during at the same time as the `UIKit` standard `ViewController.viewWillAppear()`.
+     Called at the same time as the `UIKit` standard `ViewController.viewWillAppear()`.
      
      - Parameter vc: The `WistiaPlayerViewController` whose view is about to appear.
     */
     func willAppear(wistiaPlayerViewController vc: WistiaPlayerViewController)
     
     /**
-     Called during at the same time as the `UIKit` standard `ViewController.viewWillDisappear()`.
+     Called at the same time as the `UIKit` standard `ViewController.viewWillDisappear()`.
      
      - Parameter vc: The `WistiaPlayerViewController` whose view is about to disappear.
      */

--- a/Pod/Classes/Playback/public/WistiaPlayerViewController.swift
+++ b/Pod/Classes/Playback/public/WistiaPlayerViewController.swift
@@ -440,7 +440,7 @@ public final class WistiaPlayerViewController: UIViewController {
     override final public func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         
-        pause()
+        delegate?.willDisappear(wistiaPlayerViewController: self)
         cancelChromeInteractionTimer()
         autoplayVideoWhenReady = false
     }

--- a/Pod/Classes/Playback/public/WistiaPlayerViewController.swift
+++ b/Pod/Classes/Playback/public/WistiaPlayerViewController.swift
@@ -29,14 +29,19 @@ public protocol WistiaPlayerViewControllerDelegate : class {
     func close(wistiaPlayerViewController vc: WistiaPlayerViewController)
     
     /**
-     The player has entered fullscreen mode. You are responsible for hiding the status bar and
-     navigation bar, as well as performing any other UI work to prepare for fullscreen playback.
+     Called when the player has entered fullscreen mode. You are responsible for hiding the status 
+     bar and navigation bar, as well as performing any other UI work to prepare for fullscreen 
+     playback.
+     
+     - Parameter vc: The `WistiaPlayerViewController` that entered fullscreen mode.
     */
     func didEnterFullscreen(wistiaPlayerViewController vc: WistiaPlayerViewController)
     
     /**
-     The player has exited fullscreen mode. You are responsible for un-hiding the status bar and
-     navigation bar, as well as performing any other UI work to prepare for normal playback.
+     Called when the player has exited fullscreen mode. You are responsible for un-hiding the status
+     bar and navigation bar, as well as performing any other UI work to prepare for normal playback.
+     
+     - Parameter vc: The `WistiaPlayerViewController` that exited fullscreen mode.
      */
     func didExitFullscreen(wistiaPlayerViewController vc: WistiaPlayerViewController)
 


### PR DESCRIPTION
Previously, the system would automatically pause video playback when the app entered the background. This PR removes that behavior, i.e. video playback will now continue in the background unless the host app chooses to pause it.

This PR also ensures that playback will continue uninterrupted when the device is rotated.

cc @spinosa